### PR TITLE
Set @jadnco as editorconfig owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # These owners will be the default owners for everything in the repo.
 glitch.js       @danieltamkin @darrenplace
 README.md       @danieltamkin
-*               @danieltamkin
+.editorconfig   @jadnco
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners
 # will be requested to review.


### PR DESCRIPTION
Didn't realize the all-regex for the CODEOWNERS file. Replacing that with @jadnco's participation in this repo.